### PR TITLE
moves abroot config setting out of examples

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -26,13 +26,17 @@ modules:
   commands:
   - echo Example output
 
-- name: package-modules
+- name: example-modules
   type: includes
   includes:
     - modules/50-install-debs
-    - modules/80-set-image-abroot-config
 
 # Put your custom actions before this comment
+
+- name: set-image-name-abroot
+  type: includes
+  includes:
+    - modules/80-set-image-abroot-config
 
 - name: cleanup
   type: shell


### PR DESCRIPTION
I've seen a person remove it in their image which is understandable since it is in the example section.

Moving it out should prevent confusion. 