### PR TITLE
chore: bump Vib action to v0.6.2, minor changes

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -91,10 +91,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Generate image name
       run: |

--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -23,12 +23,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install dependencies
-        run: sudo apt-get install -y jq skopeo
+        run: sudo apt-get install -y jq skopeo libfyaml-utils
 
       - name: Read base image name from recipe
         id: read_base_recipe
         run: |
-          BASE_IMAGE="$(cat recipe.yml | grep "base: " | awk -F ' ' '{print $2}')"
+          BASE_IMAGE="$(fy-filter -f recipe.yml /stages/-1/base)"
           echo The base image is $BASE_IMAGE
           if [ -z $BASE_IMAGE ]; then exit 1; fi
           echo "base_image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag testing .

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,67 +1,72 @@
-base: ghcr.io/vanilla-os/desktop:main
 name: Custom Vanilla Desktop
 id: vanilla-custom
-labels:
-  maintainer: self-maintained
-args:
-  DEBIAN_FRONTEND: noninteractive
+stages:
+- id: build
+  base: ghcr.io/vanilla-os/desktop:main
+  singlelayer: false
+  labels:
+    maintainer: self-maintained
+  args:
+    DEBIAN_FRONTEND: noninteractive
+  runs:
+  - echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
 
-modules:
-- name: init-setup
-  type: shell
-  commands:
-  - lpkg --unlock
-  - apt-get update
-
-# Put your custom actions behind this comment
-
-- name: example-packages
-  type: apt
-  source:
-    packages:
-    - vim
-
-- name: example-commands
-  type: shell
-  commands:
-  - echo Example output
-
-- name: example-modules
-  type: includes
-  includes:
-    - modules/50-install-debs
-
-# Put your custom actions before this comment
-
-- name: set-image-name-abroot
-  type: includes
-  includes:
-    - modules/80-set-image-abroot-config
-
-- name: cleanup
-  type: shell
-  commands:
-  - apt-get autoremove -y
-  - apt-get clean
-  - lpkg --lock
-
-- name: fsguard
-  type: fsguard
-  CustomFsGuard: false
-  FsGuardLocation: "/usr/sbin/FsGuard"
-  GenerateKey: true
-  FilelistPaths: ["/usr/bin"]
   modules:
-    - name: remove-prev-fsguard
-      type: shell
-      commands:
-        - rm -rf /FsGuard 
-        - rm -f ./minisign.pub ./minisign.key 
-        - chmod +x /usr/sbin/init
+  - name: init-setup
+    type: shell
+    commands:
+    - lpkg --unlock
+    - apt-get update
 
-- name: cleanup2
-  type: shell
-  commands:
-    - rm -rf /tmp/*
-    - rm -rf /var/tmp/*
-    - rm -rf /sources
+  # Put your custom actions behind this comment
+
+  - name: example-packages
+    type: apt
+    source:
+      packages:
+      - vim
+
+  - name: example-commands
+    type: shell
+    commands:
+    - echo Example output
+
+  - name: example-modules
+    type: includes
+    includes:
+      - modules/50-install-debs.yml
+
+  # Put your custom actions before this comment
+
+  - name: set-image-name-abroot
+    type: includes
+    includes:
+      - modules/80-set-image-abroot-config.yml
+
+  - name: cleanup
+    type: shell
+    commands:
+    - apt-get autoremove -y
+    - apt-get clean
+    - lpkg --lock
+
+  - name: fsguard
+    type: fsguard
+    CustomFsGuard: false
+    FsGuardLocation: "/usr/sbin/FsGuard"
+    GenerateKey: true
+    FilelistPaths: ["/usr/bin"]
+    modules:
+      - name: remove-prev-fsguard
+        type: shell
+        commands:
+          - rm -rf /FsGuard 
+          - rm -f ./minisign.pub ./minisign.key 
+          - chmod +x /usr/sbin/init
+
+  - name: cleanup2
+    type: shell
+    commands:
+      - rm -rf /tmp/*
+      - rm -rf /var/tmp/*
+      - rm -rf /sources


### PR DESCRIPTION
## Changes

- Bump Vib action to `v0.6.2`.
- Update `recipe.yml` to the new syntax.
- Add `echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends` runs to `recipe.yml` for consistency with other images.