### PR TITLE
feat: add gitignore file for vib generated dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore Vib generated directories
+/downloads/
+/sources/


### PR DESCRIPTION
When testing a recipe by building locally, Vib generates and stores the fetched files in the `downloads` and `sources` directories. These files aren't required when committing the changes, so I have added them to the newly created `gitignore` file.