### PR TITLE
fix [#28]: removes attestation verification from the workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,33 +11,8 @@ env:
     REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
-  verify-image:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: sudo apt-get install -y libfyaml-utils
-
-    - name: Read base image name from recipe
-      id: read_base_recipe
-      run: |
-        BASE_IMAGE="$(fy-filter -f recipe.yml /stages/-1/base)"
-        echo The base image is $BASE_IMAGE
-        if [ -z $BASE_IMAGE ]; then exit 1; fi
-        echo "base_image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
-        echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
-
-    - name: Verify Base Image Integrity
-      run: |
-        gh attestation verify oci://ghcr.io/${{ env.BASE_IMAGE }} --owner Vanilla-OS
-      env:
-        GH_TOKEN: ${{ github.token }}
-
   release:
     runs-on: ubuntu-latest
-    needs: verify-image
     permissions:
       contents: write # Allow actions to create release
       attestations: write # To create and write attestations

--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -15,30 +15,6 @@ env:
   BUILDX_NO_DEFAULT_ATTESTATIONS: 1
 
 jobs:
-  verify_image:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install dependencies
-      run: sudo apt-get install -y libfyaml-utils
-
-    - name: Read base image name from recipe
-      id: read_base_recipe
-      run: |
-        BASE_IMAGE="$(fy-filter -f recipe.yml /stages/-1/base)"
-        echo The base image is $BASE_IMAGE
-        if [ -z $BASE_IMAGE ]; then exit 1; fi
-        echo "base_image=$BASE_IMAGE" >> "$GITHUB_OUTPUT"
-        echo "BASE_IMAGE=$BASE_IMAGE" >> "$GITHUB_ENV"
-
-    - name: Verify Base Image Integrity
-      run: |
-        gh attestation verify oci://ghcr.io/${{ env.BASE_IMAGE }} --owner Vanilla-OS
-      env:
-        GH_TOKEN: ${{ github.token }}
-
   check_update:
     runs-on: ubuntu-latest
 
@@ -115,7 +91,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [check_update, verify_image]
+    needs: check_update
     if: ${{ needs.check_update.outputs.has_updates == 'true' }}
 
     permissions:


### PR DESCRIPTION
Attestation verification requires the base image to be owned by VanillaOS.  Otherwise, the user needs to change the build config manually.
This should not be required.

Fixes #28 